### PR TITLE
Handle windows line-endings

### DIFF
--- a/compiled_starters/docker-starter-c/Dockerfile
+++ b/compiled_starters/docker-starter-c/Dockerfile
@@ -11,4 +11,6 @@ RUN chmod +x /usr/local/bin/docker-explorer
 COPY . /app
 WORKDIR /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/compiled_starters/docker-starter-go/Dockerfile
+++ b/compiled_starters/docker-starter-go/Dockerfile
@@ -10,4 +10,6 @@ RUN chmod +x /usr/local/bin/docker-explorer
 ADD . /app
 WORKDIR /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/compiled_starters/docker-starter-nim/Dockerfile
+++ b/compiled_starters/docker-starter-nim/Dockerfile
@@ -10,4 +10,6 @@ RUN chmod +x /usr/local/bin/docker-explorer
 ADD . /app
 WORKDIR /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/compiled_starters/docker-starter-php/Dockerfile
+++ b/compiled_starters/docker-starter-php/Dockerfile
@@ -13,4 +13,6 @@ RUN chmod +x /usr/local/bin/docker-explorer
 COPY . /app
 WORKDIR /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/compiled_starters/docker-starter-rust/Dockerfile
+++ b/compiled_starters/docker-starter-rust/Dockerfile
@@ -19,4 +19,6 @@ RUN cargo clean -p docker-starter-rust --release --target-dir=/tmp/codecrafters-
 # Grab the real code
 ADD . /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/compiled_starters/docker-starter-swift/Dockerfile
+++ b/compiled_starters/docker-starter-swift/Dockerfile
@@ -6,3 +6,4 @@ RUN apt-get update && apt-get install -y curl
 ARG docker_explorer_version=v18
 RUN curl --fail -Lo /usr/local/bin/docker-explorer https://github.com/codecrafters-io/docker-explorer/releases/download/${docker_explorer_version}/${docker_explorer_version}_linux_amd64
 RUN chmod +x /usr/local/bin/docker-explorer
+

--- a/solutions/c/01-init/code/Dockerfile
+++ b/solutions/c/01-init/code/Dockerfile
@@ -11,4 +11,6 @@ RUN chmod +x /usr/local/bin/docker-explorer
 COPY . /app
 WORKDIR /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/solutions/go/01-init/code/Dockerfile
+++ b/solutions/go/01-init/code/Dockerfile
@@ -10,4 +10,6 @@ RUN chmod +x /usr/local/bin/docker-explorer
 ADD . /app
 WORKDIR /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/solutions/go/02-stdio/code/Dockerfile
+++ b/solutions/go/02-stdio/code/Dockerfile
@@ -10,4 +10,6 @@ RUN chmod +x /usr/local/bin/docker-explorer
 ADD . /app
 WORKDIR /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/solutions/go/03-exit_code/code/Dockerfile
+++ b/solutions/go/03-exit_code/code/Dockerfile
@@ -10,4 +10,6 @@ RUN chmod +x /usr/local/bin/docker-explorer
 ADD . /app
 WORKDIR /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/solutions/go/04-fs_isolation/code/Dockerfile
+++ b/solutions/go/04-fs_isolation/code/Dockerfile
@@ -10,4 +10,6 @@ RUN chmod +x /usr/local/bin/docker-explorer
 ADD . /app
 WORKDIR /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/solutions/go/05-process_isolation/code/Dockerfile
+++ b/solutions/go/05-process_isolation/code/Dockerfile
@@ -10,4 +10,6 @@ RUN chmod +x /usr/local/bin/docker-explorer
 ADD . /app
 WORKDIR /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/solutions/nim/01-init/code/Dockerfile
+++ b/solutions/nim/01-init/code/Dockerfile
@@ -10,4 +10,6 @@ RUN chmod +x /usr/local/bin/docker-explorer
 ADD . /app
 WORKDIR /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/solutions/php/01-init/code/Dockerfile
+++ b/solutions/php/01-init/code/Dockerfile
@@ -13,4 +13,6 @@ RUN chmod +x /usr/local/bin/docker-explorer
 COPY . /app
 WORKDIR /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/solutions/rust/01-init/code/Dockerfile
+++ b/solutions/rust/01-init/code/Dockerfile
@@ -19,4 +19,6 @@ RUN cargo clean -p docker-starter-rust --release --target-dir=/tmp/codecrafters-
 # Grab the real code
 ADD . /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/solutions/swift/01-init/code/Dockerfile
+++ b/solutions/swift/01-init/code/Dockerfile
@@ -6,3 +6,4 @@ RUN apt-get update && apt-get install -y curl
 ARG docker_explorer_version=v18
 RUN curl --fail -Lo /usr/local/bin/docker-explorer https://github.com/codecrafters-io/docker-explorer/releases/download/${docker_explorer_version}/${docker_explorer_version}_linux_amd64
 RUN chmod +x /usr/local/bin/docker-explorer
+

--- a/starter_templates/c/Dockerfile
+++ b/starter_templates/c/Dockerfile
@@ -11,4 +11,6 @@ RUN chmod +x /usr/local/bin/docker-explorer
 COPY . /app
 WORKDIR /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/starter_templates/go/Dockerfile
+++ b/starter_templates/go/Dockerfile
@@ -10,4 +10,6 @@ RUN chmod +x /usr/local/bin/docker-explorer
 ADD . /app
 WORKDIR /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/starter_templates/nim/Dockerfile
+++ b/starter_templates/nim/Dockerfile
@@ -10,4 +10,6 @@ RUN chmod +x /usr/local/bin/docker-explorer
 ADD . /app
 WORKDIR /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/starter_templates/php/Dockerfile
+++ b/starter_templates/php/Dockerfile
@@ -13,4 +13,6 @@ RUN chmod +x /usr/local/bin/docker-explorer
 COPY . /app
 WORKDIR /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/starter_templates/rust/Dockerfile
+++ b/starter_templates/rust/Dockerfile
@@ -19,4 +19,6 @@ RUN cargo clean -p docker-starter-rust --release --target-dir=/tmp/codecrafters-
 # Grab the real code
 ADD . /app
 
+RUN sed -i -e 's/\r$//' /app/your_docker.sh
+
 ENTRYPOINT ["/app/your_docker.sh"]

--- a/starter_templates/swift/Dockerfile
+++ b/starter_templates/swift/Dockerfile
@@ -6,3 +6,4 @@ RUN apt-get update && apt-get install -y curl
 ARG docker_explorer_version=v18
 RUN curl --fail -Lo /usr/local/bin/docker-explorer https://github.com/codecrafters-io/docker-explorer/releases/download/${docker_explorer_version}/${docker_explorer_version}_linux_amd64
 RUN chmod +x /usr/local/bin/docker-explorer
+


### PR DESCRIPTION
If a user edits a file from within Windows, there might be CR characters in it. 

Need to check: 

- Do we only have to do this for `.sh` files? What about code files like `.go`, `.py` etc? Do compilers/interpreters ignore `\r` characters automatically?
- Do we also have to run the same transformation in our test runner code before running tests?

Thanks to @jdrst for pointing this out!