### PR TITLE
Add go:build directive

### DIFF
--- a/solutions/go/05-process_isolation/code/app/main.go
+++ b/solutions/go/05-process_isolation/code/app/main.go
@@ -1,3 +1,4 @@
+// go:build linux
 package main
 
 import (

--- a/solutions/go/05-process_isolation/code/app/main.go
+++ b/solutions/go/05-process_isolation/code/app/main.go
@@ -1,4 +1,5 @@
-// go:build linux
+//go:build linux
+
 package main
 
 import (

--- a/solutions/go/05-process_isolation/diff/app/main.go.diff
+++ b/solutions/go/05-process_isolation/diff/app/main.go.diff
@@ -1,4 +1,23 @@
-@@ -19,50 +19,54 @@
+@@ -1,68 +1,73 @@
++// go:build linux
+ package main
+
+ import (
+ 	"fmt"
+ 	"io"
+ 	"io/ioutil"
+ 	"os"
+ 	"os/exec"
+ 	"path"
+ 	"syscall"
+ )
+
+ // Usage: your_docker.sh run <image> <command> <arg1> <arg2> ...
+ func main() {
+ 	command := os.Args[3]
+ 	args := os.Args[4:len(os.Args)]
+
+ 	chrootDir, err := ioutil.TempDir("", "")
  	if err != nil {
  		fmt.Printf("error creating chroot dir: %v", err)
  		os.Exit(1)

--- a/solutions/go/05-process_isolation/diff/app/main.go.diff
+++ b/solutions/go/05-process_isolation/diff/app/main.go.diff
@@ -1,5 +1,6 @@
-@@ -1,68 +1,73 @@
-+// go:build linux
+@@ -1,68 +1,74 @@
++//go:build linux
++
  package main
 
  import (


### PR DESCRIPTION
Fixes code validation errors on non-linux systems. 

Thanks to @paulchiu for highlighting this!